### PR TITLE
.editorconfig to get the tab width correct on GitHub

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# This file is for unifying the coding style for different editors and IDEs.
+# More information at http://EditorConfig.org
+
+root = true
+
+[*]
+tab_width = 8


### PR DESCRIPTION
https://github.com/nornagon/jonesforth/blob/master/jonesforth.S says:
```
Secondly make sure TABS are set to 8 characters.  The following should be a vertical line.  If not, sort out your tabs.
```
and looks like this currently:
<img width="470" height="264" alt="image" src="https://github.com/user-attachments/assets/d1e41b7a-882a-4048-beb6-cf11371cfc04" />

GitHub will honor the settings in a .editorconfig file.  [With this file in place, it looks like this](https://github.com/nedbat/jonesforth/blob/master/jonesforth.S#L100):

<img width="435" height="337" alt="image" src="https://github.com/user-attachments/assets/8cdeb24b-8c9e-4509-ad5b-9db0e77555eb" />
